### PR TITLE
Added support for old charts

### DIFF
--- a/tiller-cleanup.sh
+++ b/tiller-cleanup.sh
@@ -46,6 +46,7 @@ log "found $DEPLOYCOUNT tiller deployment names"
 # these are prefixed and postfixed by a # to enable exact match searching using grep later on
 log "get list of active tiller releases"
 kubectl --request-timeout=600s get all,cronjobs --all-namespaces -l heritage=Tiller -L release -o jsonpath='{range .items[*]}{"#"}{.metadata.labels.release}{"#\n"}{end}' | sort -u >$TMPFILE.active
+kubectl --request-timeout=600s get all,cronjobs --all-namespaces -l app.kubernetes.io/managed-by=Tiller -L app.kubernetes.io/instance -o jsonpath='{range .items[*]}{"#"}{.metadata.labels.app\.kubernetes\.io/instance}{"#\n"}{end}'|sort -u >>$TMPFILE.active
 if [ "$?" != "0" ]
 then
    echo "Error?"


### PR DESCRIPTION
Without this, I lost my old charts. Maybe this will be useful to someone else.
For example, such labels on the very common [jetstack/cert-manager](https://github.com/jetstack/cert-manager/blob/master/deploy/charts/cert-manager/templates/deployment.yaml#L6-L12) chart:
```
  labels:
    app: cert-manager
    app.kubernetes.io/instance: cert-manager
    app.kubernetes.io/managed-by: Tiller
    app.kubernetes.io/name: cert-manager
    helm.sh/chart: cert-manager-v0.10.0

```